### PR TITLE
Fix small typo in tensor gradient comment

### DIFF
--- a/src/nn/tensor.cpp
+++ b/src/nn/tensor.cpp
@@ -438,7 +438,7 @@ std::shared_ptr<Tensor> Tensor::operator*(std::shared_ptr<Tensor> other)
                 {
                     for (std::size_t j = 0; j < self->shape()[1]; j++)
                     {
-                        // everything from the i_th row contributes ot the i_th child gradient
+                        // everything from the i_th row contributes to the i_th child gradient
                         grad_self.push_back((*other)(j)*grad_output[i]);
                     }
                 }


### PR DESCRIPTION
## Summary
- fix typo in tensor gradient comment in `tensor.cpp`

## Testing
- `cmake ..`
- `make -j$(nproc)` *(fails: `error: ‘log’ is not a member of ‘std’`)*

------
https://chatgpt.com/codex/tasks/task_e_68456213cdd4832dbc568112628f0e0a