### PR TITLE
Fix Loss forward error message

### DIFF
--- a/src/nn/modules/loss.cpp
+++ b/src/nn/modules/loss.cpp
@@ -5,7 +5,7 @@
 
 std::shared_ptr<Tensor> Loss::forward(std::shared_ptr<Tensor> input)
 {
-    throw std::runtime_error("Loss expects an inputs and target.");
+    throw std::runtime_error("Loss expects an input and target.");
 }
 
 std::shared_ptr<Tensor> Loss::forward(std::shared_ptr<Tensor> input, std::size_t target)


### PR DESCRIPTION
## Summary
- correct error message for `Loss::forward`

## Testing
- `cmake ..`
- `make -j$(nproc)` *(fails: `log` is not a member of `std`)*

------
https://chatgpt.com/codex/tasks/task_e_68456221c160832d8ded8459996ebe30