### PR TITLE
Fix build error and loop initialization

### DIFF
--- a/src/nn/modules/loss.cpp
+++ b/src/nn/modules/loss.cpp
@@ -2,6 +2,8 @@
 #include "nn/modules/module.h"
 #include "nn/modules/softmax.h"
 #include "nn/tensor.h"
+#include <algorithm> // std::max
+#include <cmath>     // std::log
 
 std::shared_ptr<Tensor> Loss::forward(std::shared_ptr<Tensor> input)
 {

--- a/src/nn/tensor.cpp
+++ b/src/nn/tensor.cpp
@@ -447,7 +447,7 @@ std::shared_ptr<Tensor> Tensor::operator*(std::shared_ptr<Tensor> other)
                 {
                     // iterate through rows for the i'th column
                     float grad_other_i = 0.0f;
-                    for (std::size_t j; j < self->shape()[0]; j++)
+                    for (std::size_t j = 0; j < self->shape()[0]; j++)
                     {
                         // j_th derivated of child propagates to j_th row
                         grad_other_i += (*self)(j, i) * grad_output[j];

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -6,6 +6,7 @@
 #include "nn/serialization.h"
 #include "nn/sgd.h"
 #include "nn/tensor.h"
+#include <cmath>
 #include <fstream>
 #include <gtest/gtest.h>
 #include <iostream>


### PR DESCRIPTION
## Summary
- include `<cmath>` and `<algorithm>` for `Loss` modules
- include `<cmath>` in tests
- ensure loop variable is initialized in tensor gradient calculation
- clarify why `<algorithm>` and `<cmath>` are included

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_684562124474832d91e343e7cc1768b6