### PR TITLE
Fix uninitialized loop variable in Tensor::operator+

### DIFF
--- a/src/nn/tensor.cpp
+++ b/src/nn/tensor.cpp
@@ -266,7 +266,7 @@ std::shared_ptr<Tensor> Tensor::operator+(std::shared_ptr<Tensor> other)
                 self->add_to_grad(grad_output);
                 // broadcast in forward == sum in backward
                 float grad_other = 0.0f;
-                for (std::size_t i; i < grad_output.size(); i++)
+                for (std::size_t i = 0; i < grad_output.size(); i++)
                 {
                     grad_other += grad_output[i];
                 }


### PR DESCRIPTION
## Summary
- fix uninitialized variable `i` in `Tensor` addition backward pass

## Testing
- `cmake .. && make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_684576b829bc832d853adf67866361cf